### PR TITLE
The rstudio package no longer exists, now called rstudioapi

### DIFF
--- a/R/browse.R
+++ b/R/browse.R
@@ -7,7 +7,7 @@ browse.default = function(x, ...) {
 browse.graph = function(graph, viewer = TRUE) {
   url <- sub("db/data", "browser", attr(graph, "root"))
   if (Sys.getenv("RSTUDIO") == "1" & viewer & grepl('localhost', url)) {
-    rstudio::viewer(url)
+    rstudioapi::viewer(url)
   } else {
     browseURL(url)
   }

--- a/R/browse.R
+++ b/R/browse.R
@@ -7,7 +7,11 @@ browse.default = function(x, ...) {
 browse.graph = function(graph, viewer = TRUE) {
   url <- sub("db/data", "browser", attr(graph, "root"))
   if (Sys.getenv("RSTUDIO") == "1" & viewer & grepl('localhost', url)) {
-    rstudioapi::viewer(url)
+    if('rstudio' %in% names(installed.packages()[, 1])) {
+      rstudio::viewer(url)
+    } else {
+      rstudioapi::viewer(url)
+    }
   } else {
     browseURL(url)
   }


### PR DESCRIPTION
Newer versions of Rstudio use this package, the older one does not exist on CRAN either.