### PR TITLE
Standardized response code checking.

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -131,9 +131,9 @@ http_request = function(url, request_type, master_entity, body=NULL) {
     response = httr::DELETE(url=url, httr::config(opts), body=body)
   }
   
+  status_code = httr::status_code(response)
   status = httr::http_status(response)
-  
-  if(status$category != "Success") {
+  if(status_code != 200) {
     message = status['message']
     content = httr::content(response)
     


### PR DESCRIPTION
The capitalization of the success message varies over versions of `httr`; changed code to check for a 200 response from the GET request instead, which should be standardized.

Before this patch, I was getting errors of the form 

```
> graph = startGraph("http://10.211.112.158:7474/db/data/")
Error: success: (200) OK
```